### PR TITLE
fixed memoToPantry action

### DIFF
--- a/lib/entity/pantry.dart
+++ b/lib/entity/pantry.dart
@@ -204,7 +204,7 @@ class PantryItemList extends StateNotifier<List<PantryItem>> {
         if (item.id == id)
           item.copyWith(
             quantity: item.quantity + addQuantity,
-            newCreate: true,
+            edited: true,
           )
         else
           item,


### PR DESCRIPTION
買い物完了してパントリーに遷移したアイテムのアップロードができない問題を改善。